### PR TITLE
Added a bunch of pynbody derived arrays useful for ppd and dust.

### DIFF
--- a/diskpy/utils/__init__.py
+++ b/diskpy/utils/__init__.py
@@ -12,6 +12,11 @@ from _utils import logPrinter
 from _utils import as_simarray
 from _utils import snap_param
 from _simarraywriter import read_table, write_table
+from _simsnaputils import get_parent_snap, get_parent_param_dict, get_all_units,\
+get_snap_unit, get_snap_param, get_snap_gamma, get_snap_mu, is_isothermal, \
+polar_phi_hat, polar_r_hat
+import _derivedarrays
+
 
 __all__ = ['configparser', 'configsave', 'units_from_param', 'strip_units', 
            'set_units', 'match_units', 'findfiles', 'pbverbosity', 'str2num',
@@ -20,3 +25,6 @@ __all__ += ['logPrinter']
 __all__ += ['as_simarray']
 __all__ += ['snap_param']
 __all__ += ['read_table', 'write_table']
+__all__ + ['get_parent_snap', 'get_parent_param_dict', 'get_all_units',
+'get_snap_unit', 'get_snap_param', 'get_snap_gamma', 'get_snap_mu', 
+'is_isothermal', 'polar_phi_hat', 'polar_r_hat']

--- a/diskpy/utils/_derivedarrays.py
+++ b/diskpy/utils/_derivedarrays.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+"""
+This defines derived arrays and utility functions to extend the utility of
+tipsy SimSnaps.  Note that this has only been tested on tipsy formatted
+snapshots.
+
+The ONLY functions that should be defined OR defined as an import in this file
+should be deriveda arrays.  This is to make generating documentation on the
+derived arrays simple.
+
+i.e. don't do from module import func.  Just do import module and use 
+module.func
+
+Created on Sat Sep 16 16:17:20 2017
+
+@author: ibackus
+"""
+
+
+import numpy as np
+import pynbody
+SimArray = pynbody.array.SimArray
+
+import warnings
+
+import _simsnaputils as sutil
+
+kB = SimArray(1.0,'k')
+G = SimArray(1.0, 'G')
+
+
+# -------------------------------------------------------------------
+# Array wrappers to handle loading aux arrays with units
+# -------------------------------------------------------------------
+
+@pynbody.derived_array
+def u_dustFrac(f):
+    """
+    Returns the auxilliary array of the same name (excluding the 'u_' prefix)
+    with units inferred from the runtime parameters.
+    """
+    array_name = 'dustFrac'
+    units = '1'
+    if not pynbody.units.has_units(f[array_name]):
+        f[array_name].units = units
+    return f[array_name]
+
+@pynbody.derived_array
+def u_dustFracDot(f):
+    """
+    Returns the auxilliary array of the same name (excluding the 'u_' prefix)
+    with units inferred from the runtime parameters.
+    """
+    array_name = 'dustFracDot'
+    
+    if not pynbody.units.has_units(f[array_name]):
+        # Infer units
+        units = 1/sutil.get_snap_unit(f, 't_unit')
+        f[array_name].units = units
+    return f[array_name]
+
+@pynbody.derived_array
+def u_smoothlength(f):
+    """
+    Returns the auxilliary array of the same name (excluding the 'u_' prefix)
+    with units inferred from the runtime parameters.
+    """
+    array_name = 'smoothlength'
+    
+    if not pynbody.units.has_units(f[array_name]):
+        # Infer units
+        units = sutil.get_snap_unit(f, 'l_unit')
+        f[array_name].units = units
+    return f[array_name]
+
+@pynbody.derived_array
+def u_dustVel(f):
+    """
+    Returns the auxilliary array of the same name (excluding the 'u_' prefix)
+    with units inferred from the runtime parameters.
+    """
+    array_name = 'dustVel'
+    
+    if not pynbody.units.has_units(f[array_name]):
+        # Infer units
+        units = sutil.get_snap_unit(f, 'v_unit')
+        f[array_name].units = units
+    
+    # This is a necessary check -- currently the master branch of pynbody
+    # cannot load 3D arrays.  This has been implemented on branch issue-379
+    # of ibackus' fork, but the pull request has not been merged
+    if (np.ndim(f[array_name]) != 2) or (f[array_name].shape[1] != 3):
+        raise RuntimeError, "dustVel is a 3D array but was not read as one."\
+        "  This is problem with pynbody"
+    return f[array_name]
+
+# -------------------------------------------------------------------
+# Derived arrays
+# -------------------------------------------------------------------
+@pynbody.derived_array
+def roche_rho(f):
+    r"""
+    Roche density
+    
+    .. math::
+        \rho_{roche} \equiv M_{star}/r^3
+    
+    where :math:`r` is the distance to the center of mass of the star(s).  The
+    total star mass is used.
+    """
+    parent = sutil.get_parent_snap(f)
+    if parent != f:
+        warnings.warn("Accessing stars from parent snapshot")
+    
+    star_mass = parent.s['mass'].sum()
+    star_pos = pynbody.analysis.halo.center_of_mass(parent.s)
+    r_star = np.sqrt(((f['pos'] - star_pos)**2).sum(1))
+    rho = 16. * star_mass/r_star**3
+    rho_unit = sutil.get_snap_unit(parent, 'rho_unit')
+    return rho.in_units(rho_unit)
+
+@pynbody.derived_array
+def roche_rho_fac(f):
+    """
+    Gas density divided by roche density
+    """
+    return (f['rho']/f['roche_rho']).in_units('1')
+
+@pynbody.derived_array
+def cs(f):
+    """
+    Sound speed
+    """
+    if sutil.is_isothermal(f):
+        gamma = 1.
+    else:
+        gamma = sutil.get_snap_gamma(f)
+    m = sutil.get_snap_mu(f)
+    v_unit = sutil.get_snap_unit(f, 'v_unit')
+    c = np.sqrt(kB * f['temp']*gamma/m).in_units(v_unit)
+    return c
+
+@pynbody.derived_array
+def P(f):
+    """
+    Pressure
+    """
+    pres = f['rho'] * f['cs']**2
+    if 'dustFrac' in f.all_keys():
+        pres *= (1 - f['dustFrac'])
+    pres_unit = sutil.get_snap_unit(f, 'pres_unit')
+    return pres.in_units(pres_unit)
+
+@pynbody.derived_array
+def tstop(f):
+    """
+    Dust stopping time
+    """
+    units = sutil.get_all_units(f)
+    grainSize = SimArray(sutil.get_snap_param(f, 'dDustSize'), units['l_unit'])
+    grainDensity = SimArray(sutil.get_snap_param(f, 'dDustGrainDensity'), units['rho_unit'])
+    
+    if sutil.is_isothermal(f):
+        gamma = 1.
+    else:
+        gamma = sutil.get_snap_gamma(f)
+        
+    t = ((grainSize*grainDensity)/(f['rho'] * f['cs'])) * np.sqrt(np.pi*gamma/8.)
+    return t.in_units(units['t_unit'])
+
+@pynbody.derived_array
+def stokes(f):
+    """
+    Dust stokes parameter, defined as the dust stopping time times the 
+    Keplerian orbital angular velocity
+    
+    R is calculated relative to the origin!  NOT THE STARS!
+    """
+    parent = sutil.get_parent_snap(f)
+    Mstar = parent.s['mass'].sum()
+    tstop = f['tstop']
+    omega = np.sqrt(G*Mstar/f['rxy']**3)
+    
+    if pynbody.units.has_units(tstop) and pynbody.units.has_units(omega):
+        return (tstop*omega).in_units('1')
+    else:
+        return tstop*omega
+    
+@pynbody.derived_array
+def rho_dust(f):
+    """
+    Dust density
+    """
+    return f['u_dustFrac'] * f['rho']
+
+
+# Velocities ---------------------
+@pynbody.derived_array
+def dust_delta_v(f):
+    """
+    Dust delta v is defined as v_dust - v_gas
+    """
+    # Note: I add a small number to the denominator to avoid divide by zero
+    # as dustFrac -> 1, the gas velocity is not well defined and delta v is
+    # therefore poorly defined
+    return (f['u_dustVel'] - f['vel'])/(1 - f['u_dustFrac'][:,None] + 1e-15)
+
+@pynbody.derived_array
+def dust_delta_v_phi(f):
+    """
+    Cylindrical tangential component of the dust delta v velocity in the x-y 
+    plane.  
+    Dust delta v is defined as v_dust - v_gas
+    """
+    return sutil.polar_phi_hat(f, 'dust_delta_v')
+
+@pynbody.derived_array
+def dust_delta_v_rxy(f):
+    """
+    Radial dust delta v in x-y plane.
+    Dust delta v is defined as v_dust - v_gas
+    """
+    return sutil.polar_r_hat(f, 'dust_delta_v')
+
+
+@pynbody.derived_array
+def dustVel_phi(f):
+    """
+    Cylindrical tangential component of the dust velocity in the x-y plane
+    """
+    return sutil.polar_phi_hat(f, 'u_dustVel')
+
+@pynbody.derived_array
+def dustVel_rxy(f):
+    """
+    Radial dust velocity in the x-y plane
+    """
+    return sutil.polar_r_hat(f, 'u_dustVel')
+
+@pynbody.derived_array
+def gas_vel(f):
+    """
+    Gas velocity
+    """
+    v = f['vel']
+    if 'dustFrac' in f.all_keys():
+        v -= f['u_dustFrac'][:, None] * f['u_dustVel']
+        v /= (1 - f['u_dustFrac'][:,None] + 1e-15)
+    return v
+
+@pynbody.derived_array
+def gas_v_rxy(f):
+    """
+    Gas cylindrical radial velocity
+    """
+    return sutil.polar_r_hat(f, 'gas_vel')
+
+@pynbody.derived_array
+def gas_v_phi(f):
+    """
+    Cylindrical tangential component of the gas velocity in the x-y plane
+    """
+    return sutil.polar_phi_hat(f, 'gas_vel')
+
+@pynbody.derived_array
+def dustmass(f):
+    """
+    dustFrac * mass
+    """
+    return f['u_dustFrac'] * f['mass']
+
+# -------------------------------------------
+# analysis arrays
+# -------------------------------------------
+
+@pynbody.derived_array
+def abs_z(f):
+    """
+    Absolute value of z
+    """
+    return abs(f['z'])
+
+@pynbody.derived_array
+def dust_midplane_v(f):
+    """
+    component of delta v (v_dust - v_gas) in the direction of the midplane
+    """
+    sign = np.sign(f['z'])
+    sign.units = '1'
+    return -sign * f['dust_delta_v'][:,2]
+
+@pynbody.derived_array
+def scaleheight(f):
+    """
+    |z|/r (in cylindrical coords)
+    """
+    return (abs(f['z'])/f['rxy']).in_units('1')
+
+@pynbody.derived_array
+def abs_dust_rho_dot(f):
+    """
+    abs(rho * dustFracDot)
+    """
+    return abs(dust_rho_dot(f))
+
+@pynbody.derived_array
+def dust_rho_dot(f):
+    """
+    dustFracDot * rho
+    """
+    return f['u_dustFracDot'] * f['rho']

--- a/diskpy/utils/_simsnaputils.py
+++ b/diskpy/utils/_simsnaputils.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+"""
+Created on Sat Sep 16 17:01:21 2017
+
+@author: ibackus
+"""
+import pynbody
+SimArray = pynbody.array.SimArray
+import diskpy
+
+# ----------------------------------------------------------------------
+# Utility function
+# ----------------------------------------------------------------------
+def get_parent_snap(f):
+    """
+    Find the parent (last ancestor) of SubSnap f
+    """
+    parent = f.ancestor
+    while parent != f:
+        f = parent
+        parent = f.ancestor
+    
+    return parent
+
+def get_parent_param_dict(f):
+    """
+    Get the param dict from parent of f.  If it doesn't exist, try to infer
+    it from parent._paramfile
+    """
+    parent = get_parent_snap(f)
+    if not hasattr(parent, 'param'):
+        parent.param = diskpy.utils.snap_param(parent)
+        
+    return parent.param
+
+def get_all_units(f):
+    """
+    Retrieve a dict of units from a tipsy SimSnap
+    """
+    parent = get_parent_snap(f)
+    if not hasattr(parent, 'units'):
+        parent_dict = get_parent_param_dict(parent)
+        parent.units = diskpy.pychanga.units_from_param(parent_dict)
+    
+    return parent.units
+
+def get_snap_unit(f, unit):
+    """
+    Attempts to get the simulation units for unit
+    
+    To see available units, try get_all_units(f)
+    """
+    units = get_all_units(f)
+    return units[unit]
+
+def get_snap_param(f, key, use_defaults=False):
+    """
+    Get the runtime param from a snapshot.  IF use_defaults, keys not present
+    in the .param file will be substituted with defaults
+    """
+    param = get_parent_param_dict(f)
+    if use_defaults:
+        return diskpy.pychanga.getpar(key, param)
+    else:
+        return param[key]
+
+
+def get_snap_gamma(f):
+    """
+    Retrieve the adiabatic index for a simulation
+    """
+    gamma = get_snap_param(f, 'dConstGamma', use_defaults=True)
+    return gamma
+
+def get_snap_mu(f):
+    """
+    Retrieve the mean molecular weight for a tipsy SimSnap
+    """
+    m = get_snap_param(f, 'dMeanMolWeight', use_defaults=True)
+    return SimArray(m, 'm_p', dtype=float)
+
+def is_isothermal(f):
+    """
+    Check to see if a SimSnap is isothermal
+    """
+    param = get_parent_param_dict(f)
+    if 'bGasIsothermal' in param:
+        isothermal = (param['bGasIsothermal'] == 1)
+    elif 'bGasAdiabatic' in f.param:
+        isothermal = (param['bGasAdiabatic'] != 0)
+    else:
+        isothermal = False
+    return isothermal
+
+def polar_phi_hat(f, array):
+    """
+    Gets the phi-hat (in polar coords) component of a 2D or 3D cartesian array.
+    """
+    val = f[array]
+    if val.shape[1] not in (2, 3):
+        raise ValueError, "array to get phi-hat component of must be 2D or 3D"
+    return (f['x']*val[:,1] - f['y'] * val[:,0])/f['rxy']
+
+def polar_r_hat(f, array):
+    """
+    Gets the radial (in polar coords) component of a 2D or 3D cartesian array.
+    """
+    val = f[array]
+    if val.shape[1] not in (2, 3):
+        raise ValueError, "array to get phi-hat component of must be 2D or 3D"
+    return (f['x'] * val[:,0] + f['y'] * val[:,1])/f['rxy']


### PR DESCRIPTION
The derived arrays are defined in diskpy.utils._derivedarrays and utilities
to use them are defined in diskpy.utils._simsnaputils.  The wiki repo now
also includes a script to generate some documentation for them from their
doc strings.

Note, that reading the 3D dustVel array currently requires branch issue-379
from the ibackus fork of pynbody, since pynbody does not support reading
3D aux arrays.